### PR TITLE
ebpf: fix fullnat+ppv2 GSO stream corruption via early PPv2 insertion

### DIFF
--- a/kernel/llb_kern_cdefs.h
+++ b/kernel/llb_kern_cdefs.h
@@ -982,6 +982,32 @@ dp_rewire_port(void *tbl, struct xfi *xf)
   return bpf_redirect(*oif, BPF_F_INGRESS);
 }
 
+/* __sk_buff.gso_size is absent from older UAPI headers used by the build
+ * toolchain, so read it via its fixed ctx offset (gso_segs at 164, sk ptr at
+ * 168-175, gso_size at 176). The verifier validates ctx loads by offset, not
+ * by C type, and resolves these against the running kernel's __sk_buff.
+ * Kernels lacking the field reject the program at load time -> define
+ * HAVE_NO_SKB_GSO_CTX for such legacy targets (detection then degrades to
+ * "never GSO", i.e. current behavior).
+ */
+struct dp_skb_gso_view {
+  __u8  pad0[164];
+  __u32 gso_segs;   /* ctx offset 164 */
+  __u8  pad1[8];
+  __u32 gso_size;   /* ctx offset 176 */
+};
+
+static int __always_inline
+dp_skb_is_gso(void *md)
+{
+#ifdef HAVE_NO_SKB_GSO_CTX
+  return 0;
+#else
+  struct dp_skb_gso_view *g = md;
+  return g->gso_size > 0;
+#endif
+}
+
 static int __always_inline
 dp_is_ppv2_ipv6(struct xfi *xf)
 {
@@ -2661,6 +2687,13 @@ static int __always_inline
 dp_ins_ppv2(void *md, struct xfi *xf)
 {
   /* Not supported */
+  return 0;
+}
+
+static int __always_inline
+dp_skb_is_gso(void *md)
+{
+  /* XDP frames are never GSO super-packets */
   return 0;
 }
 

--- a/kernel/llb_kern_ct.c
+++ b/kernel/llb_kern_ct.c
@@ -303,6 +303,10 @@ dp_ct_tcp_sm(void *ctx, struct xfi *xf,
   uint32_t seq;
   uint32_t ack;
   uint32_t nstate = 0;
+  /* Read outside the spin-lock section below: no helper calls are allowed
+   * while the lock is held */
+  int is_gso = dp_skb_is_gso(ctx);
+  int defer_ppv2 = 0;
 
   if (t + 1 > dend) {
     LLBS_PPLN_DROPC(xf, LLB_PIPE_RC_PLCT_ERR);
@@ -446,10 +450,30 @@ dp_ct_tcp_sm(void *ctx, struct xfi *xf,
     }
 
     td->seq = seq;
-    if (xf->nm.ppv2)
+    if (xf->nm.ppv2) {
       nstate = CT_TCP_PEST;
-    else
+      /* Insert the ppv2 header early, on this handshake ACK: an empty ACK
+       * is never a GSO super-packet, so dp_ins_ppv2 runs on the proven
+       * single-segment path. The first data packet (e.g. TLS ClientHello,
+       * which GRO can turn into a GSO super-packet) then only needs the
+       * GSO-safe seq fixup, avoiding the FIXED_GSO stream corruption
+       * (issue #1044/#1089). If this packet itself carries piggybacked
+       * data and was GRO-merged (is_gso), defer: leave the connection
+       * unmarked and drop it, so the retransmit (a single non-GSO MSS
+       * segment) gets the header inserted instead.
+       */
+      if (td->ppv2 == 0) {
+        if (!is_gso) {
+          xf->pm.ppv2 = 1;
+          td->ppv2 = 1;
+          rtd->ppv2 = 1;
+        } else {
+          defer_ppv2 = 1;
+        }
+      }
+    } else {
       nstate = CT_TCP_EST;
+    }
     break;
 
   case CT_TCP_PEST:
@@ -461,9 +485,17 @@ dp_ct_tcp_sm(void *ctx, struct xfi *xf,
       nstate = CT_TCP_PEST;
       if (dir == CT_DIR_IN) {
         if (td->ppv2 == 0) {
-          xf->pm.ppv2 = 1;
-          td->ppv2 = 1;
-          rtd->ppv2 = 1;
+          if (!is_gso) {
+            xf->pm.ppv2 = 1;
+            td->ppv2 = 1;
+            rtd->ppv2 = 1;
+          } else {
+            /* GSO super-packet: inline insertion would corrupt the byte
+             * stream (28-byte seq hole). Drop without marking so the
+             * retransmit carries the header instead.
+             */
+            defer_ppv2 = 1;
+          }
         }
       }
     }
@@ -521,6 +553,13 @@ end:
   }
 
   bpf_spin_unlock(&atdat->lock);
+
+  if (defer_ppv2) {
+    /* The ppv2 header can only be inserted on a non-GSO packet; drop this
+     * one (connection left unmarked) and let the retransmit carry it.
+     */
+    LLBS_PPLN_DROPC(xf, LLB_PIPE_RC_PLERR);
+  }
 
   if (nstate == CT_TCP_EST) {
     return CT_SMR_EST;


### PR DESCRIPTION
dp_ins_ppv2() inserts the 28-byte PROXY v2 header with bpf_skb_adjust_room(BPF_ADJ_ROOM_NET), which GSO segmentation treats as replicated header space rather than TCP payload. When the first data packet (TLS ClientHello) arrives as a GRO/GSO super-packet the inserted bytes vanish from the stream, leaving a 28-byte seq hole: the backend waits forever and the TLS 1.3 handshake dies right after ClientHello (loxilb-io/loxilb#1044, loxilb-io/loxilb#1089; also the Windows-client failures in loxilb-io/loxilb#675 - Windows first-flight patterns commonly GRO-merge into a GSO super-packet at loxilb's NIC).

Since eBPF cannot de-GSO an skb nor mark inserted bytes as payload, move the insertion off the data packet entirely:

- Insert the PPv2 header early, on the handshake ACK that drives the SA->PEST transition. An empty ACK is never a GSO super-packet, so the proven single-segment insertion path always applies. The first data packet then only needs the GSO-safe seq fixup (+28).
- Keep the old PEST first-data trigger as a backstop, now gated on !is_gso. If the trigger packet is itself a GSO super-packet (rare: piggybacked data + GRO merge), drop it WITHOUT marking the connection so the retransmit (a single non-GSO MSS segment) carries the header.
- dp_skb_is_gso() reads __sk_buff gso_size via its fixed ctx offset (176) since the build toolchain's UAPI headers predate the field; guarded by HAVE_NO_SKB_GSO_CTX for legacy kernels, stubbed for XDP. Read before the CT spin-lock (no helper calls allowed inside).

Verified with cicd/tlsproxyprotov2 (loxilb repo): the REPRO case (MTU 320 + offload on => GSO super-packet ClientHello) flips FAIL->OK while both controls stay OK, and the backend receives the real client IP on GSO and non-GSO paths alike.