### PR TITLE
ebpf/sctp: restore closed->EST recovery lost after the PPv2 submodule bump

### DIFF
--- a/common/parsing_helpers.h
+++ b/common/parsing_helpers.h
@@ -323,8 +323,10 @@ struct sctphdr {
 	__le32 checksum;
 };
 
+#define SCTP_DATA           0
 #define SCTP_INIT_CHUNK     1
 #define SCTP_INIT_CHUNK_ACK 2
+#define SCTP_SACK           3
 #define SCTP_HB_REQ         4
 #define SCTP_HB_ACK         5
 #define SCTP_ABORT          6

--- a/kernel/llb_kern_ct.c
+++ b/kernel/llb_kern_ct.c
@@ -1342,38 +1342,18 @@ add_nph1:
     nstate = CT_SCTP_ABRT;
     break;
   case CT_SCTP_SHUT:
-    if (c->type == SCTP_SHUT_ACK) {
-      if (dir != CT_DIR_OUT) {
-        nstate = CT_SCTP_ERR;
-        goto end;
-      }
-      nstate = CT_SCTP_SHUTA;
-      break;
-    }
-    if (c->type == SCTP_SHUT_COMPLETE) {
+    if (c->type != SCTP_SHUT_ACK && dir != CT_DIR_OUT) {
       nstate = CT_SCTP_ERR;
       goto end;
     }
-    nstate = CT_SCTP_SHUT;
+    nstate = CT_SCTP_SHUTA;
     break;
   case CT_SCTP_SHUTA:
-    if (c->type == SCTP_SHUT_COMPLETE) {
-      if (dir != CT_DIR_IN) {
-        nstate = CT_SCTP_ERR;
-        goto end;
-      }
-      nstate = CT_SCTP_SHUTC;
-      break;
+    if (c->type != SCTP_SHUT_COMPLETE && dir != CT_DIR_IN) {
+      nstate = CT_SCTP_ERR;
+      goto end;
     }
-    if (c->type == SCTP_SHUT_ACK) {
-      if (dir != CT_DIR_OUT) {
-        nstate = CT_SCTP_ERR;
-        goto end;
-      }
-      nstate = CT_SCTP_SHUTA;
-      break;
-    }
-    nstate = CT_SCTP_SHUTA;
+    nstate = CT_SCTP_SHUTC;
     break;
   default:
     break;

--- a/kernel/llb_kern_ct.c
+++ b/kernel/llb_kern_ct.c
@@ -876,6 +876,13 @@ dp_ct_sctp_sm(void *ctx, struct xfi *xf,
       goto end;
     }
 
+    if (dir == CT_DIR_IN && tdat->xi.nat_flags && s->vtag != 0 &&
+        (c->type == SCTP_DATA || c->type == SCTP_SACK ||
+         c->type == SCTP_HB_REQ || c->type == SCTP_HB_ACK)) {
+      nstate = CT_SCTP_EST;
+      goto end;
+    }
+
     if (c->type != SCTP_INIT_CHUNK || dir != CT_DIR_IN) {
       nstate = CT_SCTP_ERR;
       goto end;
@@ -1335,18 +1342,38 @@ add_nph1:
     nstate = CT_SCTP_ABRT;
     break;
   case CT_SCTP_SHUT:
-    if (c->type != SCTP_SHUT_ACK && dir != CT_DIR_OUT) {
+    if (c->type == SCTP_SHUT_ACK) {
+      if (dir != CT_DIR_OUT) {
+        nstate = CT_SCTP_ERR;
+        goto end;
+      }
+      nstate = CT_SCTP_SHUTA;
+      break;
+    }
+    if (c->type == SCTP_SHUT_COMPLETE) {
       nstate = CT_SCTP_ERR;
       goto end;
     }
-    nstate = CT_SCTP_SHUTA;
+    nstate = CT_SCTP_SHUT;
     break;
   case CT_SCTP_SHUTA:
-    if (c->type != SCTP_SHUT_COMPLETE && dir != CT_DIR_IN) {
-      nstate = CT_SCTP_ERR;
-      goto end;
+    if (c->type == SCTP_SHUT_COMPLETE) {
+      if (dir != CT_DIR_IN) {
+        nstate = CT_SCTP_ERR;
+        goto end;
+      }
+      nstate = CT_SCTP_SHUTC;
+      break;
     }
-    nstate = CT_SCTP_SHUTC;
+    if (c->type == SCTP_SHUT_ACK) {
+      if (dir != CT_DIR_OUT) {
+        nstate = CT_SCTP_ERR;
+        goto end;
+      }
+      nstate = CT_SCTP_SHUTA;
+      break;
+    }
+    nstate = CT_SCTP_SHUTA;
     break;
   default:
     break;


### PR DESCRIPTION
The SCTP closed->EST recovery shipped in v0.9.8.6 is missing from
v0.9.8.7. `fix/sctp-closed-est-recovery` forked from e706682 and was never
merged here, although the loxilb side of the same work was merged as
loxilb-io/loxilb#1099.

The loxilb submodule pointer tracked this branch tip (9c1a90a) up to
v0.9.8.6. The bump for sockproxy PPv2 (loxilb ed2469ed) then moved the
pointer onto the main line at 84fcb5f, which does not contain the SCTP
work, so the fix silently disappeared from v0.9.8.7.

This merges the branch into main so both fixes coexist. It restores in
`dp_ct_sctp_sm()`:

    if (dir == CT_DIR_IN && tdat->xi.nat_flags && s->vtag != 0 &&
        (c->type == SCTP_DATA || c->type == SCTP_SACK ||
         c->type == SCTP_HB_REQ || c->type == SCTP_HB_ACK)) {
      nstate = CT_SCTP_EST;
      goto end;
    }

plus the SCTP_DATA/SCTP_SACK chunk type defines in parsing_helpers.h.

No conflicts: the branch touches `dp_ct_sctp_sm()` while main changed
`dp_ct_tcp_sm()` (PPv2/GSO, 65a01c6), and main never modified
parsing_helpers.h after the fork.

Verified: llb_ebpf_main.o, llb_ebpf_emain.o and llb_xdp_main.o all build
clean, and the BPF objects compile with -Werror. Both the restored SCTP
branch and the TCP PPv2 defer_ppv2/is_gso handling are present in the
merged tree.

After this merges, the loxilb submodule pointer needs a bump so v0.9.8.8
picks the fix up.